### PR TITLE
fix the strcpy to preserve the empty line, zero bytes apparently

### DIFF
--- a/src/parseCache.cxx
+++ b/src/parseCache.cxx
@@ -170,11 +170,13 @@ void parseCache2(const char *localPath)
   std::vector<std::string>::iterator it = cache.begin();
   for ( ; it != cache.end(); it++) {
     if (lineState == LINESTATE_HREF) {
-      strcpy(href, (*it).c_str());
+      strcpy(href, it->c_str());
+      href[it->size()] = '\0';
       lineState = LINESTATE_VERSIONNAME;
     } else {
       assert(lineState == LINESTATE_VERSIONNAME);
-      strcpy(versionName, (*it).c_str());
+      strcpy(versionName, it->c_str());
+      href[it->size()] = '\0';
       lineState = LINESTATE_HREF;
       char* hrefPtr = href;
 


### PR DESCRIPTION
this works fine on the file I submitted in the email. The error I was getting last night can be summed up in a conversation I had on the mailing list with Curt and Jens. 

https://sourceforge.net/p/flightgear/mailman/message/35053026/
