### PR TITLE
Fixed missing ')'

### DIFF
--- a/scripts/d-and-c/make3rd.x64.bat
+++ b/scripts/d-and-c/make3rd.x64.bat
@@ -132,6 +132,8 @@ md %WORKSPACE%\%TMP3RD%\include
 @REM GOTO DO_CGAL
 @REM GOTO DO_GDAL 
 @REM GOTO DO_BOOST
+@REM GOTO DO_JPEG
+@REM GOTO DO_AL
 @set _TMP_LIBS=
 
 :DO_ZLIB
@@ -656,7 +658,9 @@ cd %WORKSPACE%
 IF %HAVELOG% EQU 1 (
 @echo %0: ############################# Download ^& compile LIBBOOST to %LOGFIL%
 )
-
+@REM check to see if we have a boost installation we can use. Checking %BOOST_ROOT%
+@echo Checking for local installation of boost...
+@if NOT "%BOOST_ROOT%"=="" GOTO DN_BOOST 
 @REM But must have something of boost, even at this early stage
 @echo But must have something of boost, even at this early stage... UGH!
 @REM GOTO DO_BOOST2
@@ -727,7 +731,7 @@ CD %TMP_SRC%
 @REM )
 
 :DN_BOOST 
-
+@echo %BOOST_ROOT%
 cd %WORKSPACE%
 
 :DO_CGAL
@@ -1250,6 +1254,7 @@ xcopy %WORKSPACE%\plib-build\build\lib\*.lib %WORKSPACE%\%TMP3RD%\lib /y /q
 @set _TMP_BLD_FAIL=%_TMP_BLD_FAIL% OpenAL
 )
 @set _TMP_LIBS=%_TMP_LIBS% OpenAL
+)
 :DN_AL
 
 :END

--- a/scripts/d-and-c/openal-build.bat
+++ b/scripts/d-and-c/openal-build.bat
@@ -17,7 +17,7 @@
 @set BLDDBG=1
 @set TMPROOT=..
 
-@set SET_BAT=%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
+@set SET_BAT=%ProgramFiles(x86)%\Microsoft Visual Studio %_MSVS%.0\VC\vcvarsall.bat
 @if NOT EXIST "%SET_BAT%" goto NOBAT
 @if NOT EXIST %TMPROOT%\nul goto NOROOT
 @REM set TMPSRC=..\openal-source
@@ -26,21 +26,17 @@
 @if /I "%PROCESSOR_ARCHITECTURE%" EQU "AMD64" (
 @set TMPINST=%TMPROOT%\3rdParty.x64
 ) ELSE (
- @if /I "%PROCESSOR_ARCHITECTURE%" EQU "x86_64" (
-@set TMPINST=%TMPROOT%\3rdParty.x64
- ) ELSE (
 @echo ERROR: Appears 64-bit is NOT available... aborting...
 @goto ISERR
- )
 )
 @if NOT EXIST %TMPINST%\nul goto NOINST
 
 @echo Doing build output to %TMPLOG%
 @echo Doing build output to %TMPLOG% > %TMPLOG%
 
-@echo Doing: 'call "%SET_BAT%" %PROCESSOR_ARCHITECTURE%'
-@echo Doing: 'call "%SET_BAT%" %PROCESSOR_ARCHITECTURE%' >> %TMPLOG%
-@call "%SET_BAT%" %PROCESSOR_ARCHITECTURE% >> %TMPLOG% 2>&1
+@echo Doing: 'call "%SET_BAT%" %BUILD_BITS%
+@echo Doing: 'call "%SET_BAT%" %BUILD_BITS%' >> %TMPLOG%
+@call "%SET_BAT%" %BUILD_BITS% >> %TMPLOG% 2>&1
 @if ERRORLEVEL 1 goto ERR0
 @REM call setupqt64
 @cd %BLDDIR%
@@ -57,7 +53,7 @@
 @REM ##########################################
 @REM set TMPINST=F:\Projects\software.x64
 @set TMPOPTS=-DCMAKE_INSTALL_PREFIX=%TMPINST%
-@set TMPOPTS=%TMPOPTS% -G "Visual Studio 10 Win64"
+@set TMPOPTS=%TMPOPTS% -G "Visual Studio %_MSVS% Win64"
 
 :RPT
 @if "%~1x" == "x" goto GOTCMD


### PR DESCRIPTION
Tweaked openal-build.bat to use %_MSVS
Check to see if %BOOST_ROOT% is already set, skip building

Possible add a switch to build boost regardless if it is already installed locally. /B?
