### PR TITLE
Still need escape characters (\) for Perl. Convoluted, but works

### DIFF
--- a/scripts/d-and-c/make3rd.x64.bat
+++ b/scripts/d-and-c/make3rd.x64.bat
@@ -357,7 +357,7 @@ IF %HAVELOG% EQU 1 (
 @echo 	      $line = $lines[$i]; >>%PERL_FIL%
 @echo         $line =~ s/Win32/x64/g; >>%PERL_FIL%
 @if %_MSVS% GTR 10 (
-@echo         $line =~ s/^<CharacterSet^>Unicode^<^/CharacterSet^>^/^<CharacterSet^>Unicode^<^/CharacterSet^>^\n^<PlatformToolset^>v%_MSVS%0^<^/PlatformToolset^>^/g; >>%PERL_FIL%
+@echo         $line =~ s/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>^/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>^\n\^<PlatformToolset\^>v%_MSVS%0\^<\^/PlatformToolset\^>^/g; >>%PERL_FIL%
 )
 @echo         $lines[$i] = $line; >>%PERL_FIL%
 @echo     } >>%PERL_FIL%

--- a/scripts/d-and-c/make3rd.x64.bat
+++ b/scripts/d-and-c/make3rd.x64.bat
@@ -357,7 +357,7 @@ IF %HAVELOG% EQU 1 (
 @echo 	      $line = $lines[$i]; >>%PERL_FIL%
 @echo         $line =~ s/Win32/x64/g; >>%PERL_FIL%
 @if %_MSVS% GTR 10 (
-@echo         $line =~ s/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>^/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>^\n\^<PlatformToolset\^>v%_MSVS%0\^<\^/PlatformToolset\^>^/g; >>%PERL_FIL%
+@echo         $line =~ s/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>^/\^<CharacterSet\^>Unicode\^<\^/CharacterSet\^>\n\^<PlatformToolset\^>v%_MSVS%0\^<\^/PlatformToolset\^>^/g; >>%PERL_FIL%
 )
 @echo         $lines[$i] = $line; >>%PERL_FIL%
 @echo     } >>%PERL_FIL%


### PR DESCRIPTION
This works for me as you intended

`Doing 'msbuild jpeg.vcxproj /t:Build /p:Configuration=Release;Platform=x64' to c:\development\build\3rdParty-build\bldlog-2.txt
Installing the jpeg built components...'`

success
